### PR TITLE
Add scroll-triggered reveal animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
   <div>
     <div class="timeline" style="--items: 7;">
         <ul>
-         <li style="--index: 1">
+         <li class="reveal-on-scroll" style="--index: 1">
           <h3>
            Nov 2019 - Jun 2025
           </h3>
@@ -246,7 +246,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
           <p>
           </p>
          </li>
-         <li style="--index: 2">
+         <li class="reveal-on-scroll" style="--index: 2">
           <h3>
            Feb-May 2022
           </h3>
@@ -260,7 +260,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
           <p>
           </p>
          </li>
-         <li style="--index: 3">
+         <li class="reveal-on-scroll" style="--index: 3">
           <h3>
            Jun 2022
           </h3>
@@ -274,7 +274,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
           <p>
           </p>
          </li>
-         <li style="--index: 4">
+         <li class="reveal-on-scroll" style="--index: 4">
           <h3>
            Sept-Dec 2024
           </h3>
@@ -288,7 +288,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
           <p>
           </p>
          </li>
-         <li style="--index: 5">
+         <li class="reveal-on-scroll" style="--index: 5">
           <h3>
            Jun 2025
           </h3>
@@ -302,7 +302,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
           <p>
           </p>
          </li>
-         <li style="--index: 6">
+         <li class="reveal-on-scroll" style="--index: 6">
           <h3>
            Next
           </h3>
@@ -384,42 +384,42 @@ Blend in. Speak like an AI… or be eliminated.</p>
     <h2 class="it-projects-section-title" data-translate-key="itProjectsSectionTitle">IT Projects</h2>
     <div class="it-cards-container">
       <!-- Card 1 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/Img_IT_CP2.webp" alt="Constraint programming Icon" class="it-project-icon">
         <h3 data-translate-key="itConstraintProgrammingTitle">Constraint programming</h3>
         <p class="it-project-year" data-translate-key="itConstraintProgrammingYear">2024</p>
         <p class="it-project-description" data-translate-key="itConstraintProgrammingDesc">Modelling and solving instances of a logistics and transport problem using constraint programming.</p>
       </div>
       <!-- Card 2 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/Img_IT_Compiler.webp" alt="Compiler Icon" class="it-project-icon">
         <h3 data-translate-key="itCompilerTitle">Compiler<br><br></h3>
         <p class="it-project-year" data-translate-key="itCompilerYear">2024</p>
         <p class="it-project-description" data-translate-key="itCompilerDesc">Coding a complet compiler that transforms an invented language into Java bytecode, from lexical analysis in the code to translating it into executable instructions.</p>
       </div>
       <!-- Card 3 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/Img_IT_MachineLearning.webp" alt="Machine learning Icon" class="it-project-icon">
         <h3 data-translate-key="itMachineLearningTitle">Machine learning</h3>
         <p class="it-project-year" data-translate-key="itMachineLearningYear">2024</p>
         <p class="it-project-description" data-translate-key="itMachineLearningDesc">We tackled a binary classification task using a real industrial dataset that was diverse and poorly cleaned, spread across multiple CSV files with many variables but few observations. We could use any machine learning techniques we wanted.​</p>
       </div>
       <!-- Card 4 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/img_IT_RepairPal.webp" alt="Car Damage APP Icon" class="it-project-icon">
         <h3 data-translate-key="itCarDamageAppTitle">Car Damage APP</h3>
         <p class="it-project-year" data-translate-key="itCarDamageAppYear">2023</p>
         <p class="it-project-description" data-translate-key="itCarDamageAppDesc">For my Software course, I worded on the Car Damage App (RepairPal) (by NRB)  to enable quick damage detection and repair cost estimates after accidents, aiding users and insurers.</p>
       </div>
       <!-- Card 5 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/img_IT_SRv6b.webp" alt="SRV6 - TRAFFIC ENGINEERING Icon" class="it-project-icon">
         <h3 data-translate-key="itSRV6Title">SRV6 - TRAFFIC ENGINEERING</h3>
         <p class="it-project-year" data-translate-key="itSRV6Year">2023</p>
         <p class="it-project-description" data-translate-key="itSRV6Desc">I utilized Containerlab and FRRouting to simulate a 14-node network topology, assessing Traffic Engineering by adding artificial delays to optimize data routing across various paths.</p>
       </div>
       <!-- Card 6 -->
-      <div class="it-project-card">
+      <div class="it-project-card reveal-on-scroll">
         <img src="./index_files/img_IT_OZ.webp" alt="Text preacher Icon" class="it-project-icon">
         <h3 data-translate-key="itTextPreacherTitle">Text preacher<br><br></h3>
         <p class="it-project-year" data-translate-key="itTextPreacherYear">2023</p>
@@ -731,6 +731,7 @@ Blend in. Speak like an AI… or be eliminated.</p>
   <script src="theme-switcher.js" defer></script>
   <script src="navbar.js" defer></script>
   <script src="modal.js" defer></script>
+  <script src="scroll-animations.js" defer></script>
 
   <!-- Footer Section -->
      <footer id="contact" class="site-footer"> <!-- Example id="contact" if you want a "Contact" link to scroll here -->

--- a/scroll-animations.js
+++ b/scroll-animations.js
@@ -1,0 +1,43 @@
+const initScrollAnimations = () => {
+  const revealElements = document.querySelectorAll('.reveal-on-scroll');
+
+  if (revealElements.length === 0) {
+    return;
+  }
+
+  const showElement = (element) => {
+    element.classList.add('is-visible');
+  };
+
+  if (!('IntersectionObserver' in window)) {
+    revealElements.forEach(showElement);
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+      } else {
+        entry.target.classList.remove('is-visible');
+      }
+    });
+  }, {
+    threshold: 0.2,
+  });
+
+  revealElements.forEach((element) => {
+    observer.observe(element);
+
+    const rect = element.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      showElement(element);
+    }
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initScrollAnimations);
+} else {
+  initScrollAnimations();
+}

--- a/style.css
+++ b/style.css
@@ -1838,3 +1838,21 @@ my-journey {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.55s ease, transform 0.55s ease;
+}
+
+.reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-on-scroll {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add the `reveal-on-scroll` hook to timeline items and IT project cards to prepare them for animation
- define shared reveal styles with smooth transitions and a reduced-motion fallback
- introduce an IntersectionObserver script to toggle `is-visible` based on viewport visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da50347ed88333a44bfced43939512