### PR TITLE
Optimize hero performance and loading

### DIFF
--- a/hero-visuals.js
+++ b/hero-visuals.js
@@ -53,10 +53,12 @@ const initHeroOrbit = () => {
   let width = 0;
   let height = 0;
   let dpr = Math.min(window.devicePixelRatio || 1, 1.75);
+  let isInView = false;
+  let isAnimating = false;
 
   class Particle {
     constructor() {
-      this.size = Math.random() * 1.4 + 0.6;
+      this.size = Math.random() * 1.2 + 0.5;
       this.angle = Math.random() * Math.PI * 2;
       this.angleVelocity = 0.0025 + Math.random() * 0.0035;
       this.velocityScale = 0.15 + Math.random() * 0.25;
@@ -114,10 +116,10 @@ const initHeroOrbit = () => {
   };
 
   const determineTargetParticleCount = () => {
-    const baseCount = window.innerWidth < 768 ? 45 : 90;
+    const baseCount = window.innerWidth < 768 ? 32 : 58;
     const areaFactor = Math.sqrt((width * height) / (1200 * 700));
-    const scaled = Math.round(baseCount * Math.min(1.6, Math.max(0.65, areaFactor)));
-    return Math.max(35, Math.min(140, scaled));
+    const scaled = Math.round(baseCount * Math.min(1.35, Math.max(0.6, areaFactor)));
+    return Math.max(26, Math.min(92, scaled));
   };
 
   const syncParticleCount = () => {
@@ -133,12 +135,13 @@ const initHeroOrbit = () => {
   };
 
   const drawConnections = () => {
-    const maxDistance = Math.min(180, Math.max(110, Math.max(width, height) * 0.18));
+    const maxDistance = Math.min(160, Math.max(100, Math.max(width, height) * 0.16));
     const maxDistanceSq = maxDistance * maxDistance;
 
     for (let i = 0; i < particles.length; i += 1) {
       const p1 = particles[i];
-      for (let j = i + 1; j < particles.length; j += 1) {
+      const neighborCap = Math.min(particles.length, i + 12);
+      for (let j = i + 1; j < neighborCap; j += 1) {
         const p2 = particles[j];
         const dx = p1.x - p2.x;
         const dy = p1.y - p2.y;
@@ -207,7 +210,8 @@ const initHeroOrbit = () => {
   };
 
   const render = () => {
-    if (isMotionDisabled) {
+    if (isMotionDisabled || !isInView) {
+      isAnimating = false;
       return;
     }
 
@@ -242,15 +246,16 @@ const initHeroOrbit = () => {
       cancelAnimationFrame(animationFrame);
       animationFrame = undefined;
     }
+    isAnimating = false;
   };
 
   const startAnimation = () => {
-    if (isMotionDisabled) {
-      stopAnimation();
+    if (isMotionDisabled || !isInView || isAnimating) {
       return;
     }
 
     stopAnimation();
+    isAnimating = true;
     render();
   };
 
@@ -260,7 +265,7 @@ const initHeroOrbit = () => {
   };
 
   const handleVisibilityChange = () => {
-    if (document.hidden || isMotionDisabled) {
+    if (document.hidden || isMotionDisabled || !isInView) {
       stopAnimation();
     } else {
       startAnimation();
@@ -270,7 +275,28 @@ const initHeroOrbit = () => {
   readColorVariables();
   resizeCanvas();
   syncParticleCount();
-  startAnimation();
+
+  const intersectionHandler = (entries) => {
+    entries.forEach((entry) => {
+      isInView = entry.isIntersecting;
+
+      if (isInView && !isMotionDisabled) {
+        startAnimation();
+      } else {
+        stopAnimation();
+      }
+    });
+  };
+
+  if ('IntersectionObserver' in window) {
+    const intersectionObserver = new IntersectionObserver(intersectionHandler, {
+      threshold: 0.18,
+    });
+    intersectionObserver.observe(heroSection);
+  } else {
+    isInView = true;
+    startAnimation();
+  }
 
   const resizeObserver = 'ResizeObserver' in window ? new ResizeObserver(handleResize) : null;
   if (resizeObserver) {
@@ -310,7 +336,9 @@ const initHeroOrbit = () => {
       readColorVariables();
       resizeCanvas();
       syncParticleCount();
-      startAnimation();
+      if (isInView) {
+        startAnimation();
+      }
     }
   };
 

--- a/index.html
+++ b/index.html
@@ -57,7 +57,8 @@
   <!-- Favicon -->
   <link rel="icon" href="./index_files/icon_JustinVanwichelen.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" as="style" onload="this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
 </head>
 <body id="home">
   <!-- Navbar Section -->
@@ -92,7 +93,18 @@
       </div>
       <div class="hero-content">
         <div class="hero-portrait reveal-on-scroll">
-          <img src="index_files/cv_photo2.svg" alt="Portrait of Justin Vanwichelen" class="hero-image">
+          <picture>
+            <img
+              src="index_files/cv_photo2.svg"
+              alt="Portrait of Justin Vanwichelen"
+              class="hero-image"
+              width="320"
+              height="320"
+              decoding="async"
+              fetchpriority="high"
+              loading="eager"
+            >
+          </picture>
         </div>
         <div class="hero-text reveal-on-scroll">
           <p class="hero-role-chip" data-translate-key="heroRoleChip">Game Developer • AI Storycrafter</p>
@@ -108,7 +120,9 @@
       </div>
       <div class="hero-scroll-indicator reveal-on-scroll">
         <span data-translate-key="heroScrollCue">Scroll to explore my universes</span>
-        <i class="fa-solid fa-angle-down" aria-hidden="true"></i>
+        <svg class="hero-scroll-icon" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+          <path d="M12 16.5a1 1 0 0 1-.7-.29l-6-6a1 1 0 1 1 1.4-1.42L12 14.09l5.3-5.3a1 1 0 0 1 1.4 1.42l-6 6a1 1 0 0 1-.7.29z" fill="currentColor"/>
+        </svg>
       </div>
     </div>
   </header>

--- a/style.css
+++ b/style.css
@@ -363,28 +363,11 @@ iframe {
   pointer-events: none;
   z-index: 0;
   overflow: hidden;
-}
-
-.hero-background::before,
-.hero-background::after {
-  content: "";
-  position: absolute;
-  inset: -35% -20% -25% -20%;
-  background: radial-gradient(circle at 20% 20%, rgba(var(--hero-particle-trail), 0.38), transparent 10%),
-              radial-gradient(circle at 80% 30%, rgba(var(--hero-particle-core), 0.3), transparent 10%),
-              radial-gradient(circle at 50% 85%, rgba(var(--hero-particle-highlight), 0.25), transparent 0%);
-  filter: blur(0);
-  transform-origin: center;
-}
-
-.hero-background::before {
-  animation: heroGlow 32s linear infinite;
-  mix-blend-mode: screen;
-}
-
-.hero-background::after {
-  animation: heroGlowReverse 38s linear infinite;
-  opacity: 0.55;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(var(--hero-particle-trail), 0.32), transparent 55%),
+    radial-gradient(circle at 72% 28%, rgba(var(--hero-particle-core), 0.28), transparent 60%),
+    radial-gradient(circle at 48% 78%, rgba(var(--hero-particle-highlight), 0.22), transparent 62%),
+    linear-gradient(160deg, rgba(13, 28, 64, 0.85), rgba(6, 12, 32, 0.94));
 }
 
 .hero-canvas {
@@ -393,6 +376,7 @@ iframe {
   width: 100%;
   height: 100%;
   display: block;
+  opacity: 0.65;
 }
 
 .hero-content {
@@ -409,9 +393,10 @@ iframe {
   position: relative;
   display: grid;
   place-items: center;
-    margin-top: 0;
+  margin-top: 0;
   border-radius: 50%;
   isolation: isolate;
+  aspect-ratio: 1 / 1;
 }
 
 .hero-portrait::before,
@@ -420,24 +405,25 @@ iframe {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  background: linear-gradient(135deg, rgba(var(--hero-particle-highlight), 0.85), rgba(var(--hero-particle-core), 0.75));
+  background: linear-gradient(135deg, rgba(var(--hero-particle-highlight), 0.65), rgba(var(--hero-particle-core), 0.55));
   filter: blur(0);
-  opacity: 0.9;
+  opacity: 0.7;
   z-index: -2;
 }
 
 .hero-portrait::after {
-  inset: clamp(-1.2rem, -2vw, -0.8rem);
-  opacity: 0.35;
-  filter: blur(30px);
+  inset: clamp(-0.6rem, -1.5vw, -0.4rem);
+  opacity: 0.25;
+  filter: blur(18px);
 }
 
 .hero-image {
   max-width: min(320px, 68vw);
+  width: 100%;
+  height: auto;
   border-radius: 50%;
   padding: 0;
   box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
-  animation: heroFloat 12s ease-in-out infinite;
 }
 
 .hero-text {
@@ -535,19 +521,16 @@ iframe {
   color: rgba(var(--hero-pointer-highlight), 0.8);
   font-weight: 600;
   z-index: 1;
-  animation: heroScrollHint 3.2s ease-in-out infinite;
 }
 
-.hero-scroll-indicator i {
-  font-size: 1.1rem;
+.hero-scroll-icon {
+  width: 1.1rem;
+  height: 1.1rem;
   color: currentColor;
-  animation: heroScrollIcon 1.8s ease-in-out infinite;
+  flex-shrink: 0;
 }
 
-.hero-section.is-reduced-motion .hero-background::before,
-.hero-section.is-reduced-motion .hero-background::after,
 .hero-section.is-reduced-motion .hero-scroll-indicator,
-.hero-section.is-reduced-motion .hero-scroll-indicator i,
 .hero-section.is-reduced-motion .hero-image {
   animation: none;
 }
@@ -560,56 +543,6 @@ iframe {
   .hero-section {
     min-height: clamp(420px, 52vh, 640px);
     padding-bottom: clamp(2.25rem, 4vw, 3.75rem);
-  }
-}
-
-@keyframes heroGlow {
-  from {
-    transform: rotate(0deg) scale(1.05);
-  }
-  to {
-    transform: rotate(360deg) scale(1.05);
-  }
-}
-
-@keyframes heroGlowReverse {
-  from {
-    transform: rotate(360deg) scale(1.05);
-  }
-  to {
-    transform: rotate(0deg) scale(1.05);
-  }
-}
-
-@keyframes heroFloat {
-  0%,
-  100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-14px);
-  }
-}
-
-@keyframes heroScrollHint {
-  0%,
-  100% {
-    opacity: 0.55;
-    transform: translate(-50%, 0px);
-  }
-  50% {
-    opacity: 1;
-    transform: translate(-50%, -12px);
-  }
-}
-
-@keyframes heroScrollIcon {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(6px);
   }
 }
 


### PR DESCRIPTION
## Summary
- add fetch-priority hints for the hero portrait and defer font-awesome loading to avoid blocking render
- simplify hero background styling and scroll cue while keeping layout intact
- throttle the canvas particle system so it only runs when the hero is in view and with fewer connections

## Testing
- [x] Manually viewed hero section in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dd1eb352208333b3bd76773ef7a2e5