### PR TITLE
Improve mobile layout spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -626,6 +626,16 @@ iframe {
     max-width: 320px;
     height: auto;
   }
+  .hero-cta-group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+  .hero-cta-group .btn-cta-primary,
+  .hero-cta-group .btn-cta-secondary {
+    max-width: none;
+    width: 100%;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -928,23 +938,49 @@ iframe {
   }
 }
 @media (max-width: 768px) {
-  .hero-section { 
-    padding-top: 70px; 
+  .hero-section {
+    padding-top: 70px;
+  }
+  .hero-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: clamp(1.75rem, 6vw, 2.75rem);
+  }
+  .hero-text {
+    max-width: min(520px, 100%);
+    text-align: center;
+  }
+  .hero-text h2 {
+    text-align: center;
+  }
+  .hero-portrait {
+    width: min(260px, 65vw);
+  }
+  .navbar {
+    padding: 0.5rem 0;
   }
   .navbar ul {
-    flex-direction: row; 
-    justify-content: space-between; 
+    flex-direction: row;
+    justify-content: space-between;
     align-items: center;
-    padding: 0 1rem; 
-    position: relative; 
+    padding: 0 1rem;
+    position: relative;
+    flex-wrap: nowrap;
+    gap: 0.75rem;
   }
   .hamburger-menu {
-    display: flex; 
-    order: 1; 
+    display: flex;
+    order: 0;
+    flex: 0 0 auto;
   }
   .navbar .theme-toggle-item {
-    margin-left: 0; 
-    order: 2; 
+    margin-left: auto;
+    order: 2;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
   }
   .navbar ul .nav-links-group {
     display: none;
@@ -983,8 +1019,37 @@ iframe {
     background-color: var(--accent-color);
     color: var(--body-bg-color); 
   }
-  .light-theme .navbar ul .nav-links-group li a:hover { 
-    color: var(--navbar-bg-color-light); 
+  .light-theme .navbar ul .nav-links-group li a:hover {
+    color: var(--navbar-bg-color-light);
+  }
+  #theme-toggle-btn {
+    position: static;
+    top: auto;
+    right: auto;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0.55rem 1.1rem;
+    font-size: 0.85rem;
+  }
+  .language-switcher {
+    order: 3;
+    width: auto;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+  .language-switcher button {
+    flex: 0 0 auto;
+    padding: 0.4rem 0.75rem;
+  }
+  .hero-cta-group {
+    justify-content: center;
+    width: 100%;
+  }
+  .hero-cta-group .btn-cta-primary,
+  .hero-cta-group .btn-cta-secondary {
+    flex: 1 1 100%;
+    max-width: 320px;
   }
   .hamburger-menu.open .hamburger-menu__line:nth-child(1) {
     transform: rotate(45deg) translate(5px, 5px);


### PR DESCRIPTION
## Summary
- center and stack hero content and calls-to-action on small screens for better spacing
- reorganize the mobile navigation controls so the hamburger, theme toggle, and language switcher share one row with slimmer header padding

## Testing
- not run (CSS changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd61647e2c8333aee82615145d87c0