### PR TITLE
Improve SEO visibility for Justin Vanwichelen portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,26 +19,37 @@
   <meta name="keywords" data-translate-key="metaKeywords" content="Justin Vanwichelen, Portfolio, Technical Artist, Game Developer, AI, Computer Science, Unreal Engine, Unity, HEAJ, UCLouvain, Game Development, Interactive Systems, Gameplay Programming, Technical Art, AI in Games, Game Design, Game Projects, IT Projects">
   <meta name="author" content="Justin Vanwichelen">
   <meta name="robots" content="index, follow">
+  <meta name="googlebot" content="index, follow">
+  <meta name="bingbot" content="index, follow">
+  <meta name="profile:first_name" content="Justin">
+  <meta name="profile:last_name" content="Vanwichelen">
 
   <!-- Canonical & Alternate -->
   <link rel="canonical" href="https://justinvanwichelen.be/">
   <link rel="alternate" hreflang="en" href="https://justinvanwichelen.be/">
   <link rel="alternate" hreflang="fr" href="https://justinvanwichelen.be/?lang=fr">
+  <link rel="me" href="https://github.com/JustinVanwichelen">
 
   <!-- Open Graph / Facebook Meta Tags -->
   <meta property="og:title" content="Justin Vanwichelen's Portfolio – Developer">
   <meta property="og:description" content="Explore the portfolio of Justin Vanwichelen, showcasing projects in game development, AI, and technical art.">
   <meta property="og:image" content="./index_files/metaPreview_JustinVanwichelen.png">
-  <meta property="og:url" content="http://justinvanwichelen.be/">
-  <meta property="og:type" content="website">
+  <meta property="og:image:alt" content="Justin Vanwichelen portfolio preview">
+  <meta property="og:url" content="https://justinvanwichelen.be/">
+  <meta property="og:type" content="profile">
   <meta property="og:site_name" content="Justin Vanwichelen Portfolio">
   <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
+  <meta property="og:profile:first_name" content="Justin">
+  <meta property="og:profile:last_name" content="Vanwichelen">
+  <meta property="og:profile:username" content="justinvanwichelen">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Justin Vanwichelen's Portfolio – Developer">
   <meta name="twitter:description" content="Explore the portfolio of Justin Vanwichelen, showcasing projects in game development, AI, and technical art.">
   <meta name="twitter:image" content="./index_files/metaPreview_JustinVanwichelen.png">
+  <meta name="twitter:image:alt" content="Justin Vanwichelen portfolio preview">
 
   <!-- Structured Data -->
   <script type="application/ld+json">
@@ -48,9 +59,46 @@
     "name": "Justin Vanwichelen",
     "url": "https://justinvanwichelen.be/",
     "description": "Explore the portfolio of Justin Vanwichelen, showcasing projects in game development, AI, and technical art.",
+    "image": "https://justinvanwichelen.be/index_files/metaPreview_JustinVanwichelen.png",
+    "jobTitle": "Game Developer and Technical Artist",
+    "knowsAbout": [
+      "Gameplay programming",
+      "Artificial Intelligence",
+      "Technical art",
+      "Interactive storytelling"
+    ],
+    "alumniOf": [
+      {
+        "@type": "EducationalOrganization",
+        "name": "Université catholique de Louvain"
+      },
+      {
+        "@type": "EducationalOrganization",
+        "name": "Haute École Albert Jacquard"
+      }
+    ],
+    "hasOccupation": {
+      "@type": "Occupation",
+      "name": "Game Developer",
+      "description": "Designs and implements interactive game systems and AI-driven experiences."
+    },
     "sameAs": [
       "https://github.com/JustinVanwichelen"
     ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Justin Vanwichelen Portfolio",
+    "url": "https://justinvanwichelen.be/",
+    "inLanguage": ["en", "fr"],
+    "creator": {
+      "@type": "Person",
+      "name": "Justin Vanwichelen"
+    }
   }
   </script>
 
@@ -111,7 +159,7 @@
         </div>
         <div class="hero-text" data-animate data-animate-step="2">
           <p class="hero-role-chip" data-translate-key="heroRoleChip">Game Developer • AI Storycrafter</p>
-          <h2 data-translate-key="heroGreeting">HI ALL, I'M <STRong>JUSTIN 👋</STRong></h2>
+          <h1 data-translate-key="heroGreeting">HI ALL, I'M <STRong>JUSTIN 👋</STRong></h1>
           <p data-translate-key="heroP1">With a background as a <strong>Technical Artist</strong> and a <strong>Master's degree in Computer Science</strong> with a specialization in <strong>Artificial Intelligence</strong>, I focus on <strong>gameplay programming</strong> and interactive systems development. My strong creative instincts, paired with my technical skills, allow me to design <strong>immersive and intelligent experiences</strong>.</p>
           <p data-translate-key="heroP2">I enjoy <strong>blending logic with aesthetics</strong>. I'm proficient in <strong>Photoshop</strong> and love crafting detailed visual assets, especially during prototyping and early design phases.</p>
           <p data-translate-key="heroP3">My Master's thesis explores how AI, particularly <strong>Large Language Models (LLMs)</strong>, can enhance interactivity and narrative depth in role-playing games. I've also applied AI in healthcare through a health informatics course, broadening my perspective on its cross-industry impact.</p>
@@ -133,6 +181,7 @@
 
 
     <!-- Highlighted projects Section  -->
+  <main id="main-content">
   <h2 class="carousel-header" data-translate-key="carouselHeader">Highlighted projects</h2>
   <div class="carousel-container">
     <button class="arrow nav left" id="prev-btn"><i class="fas fa-chevron-left"></i></button>
@@ -953,6 +1002,8 @@ Blend in. Speak like an AI… or be eliminated.</p>
     }
   }
   </script>
+
+  </main>
 
   <!-- Modal Structure -->
   <div class="modal-overlay" id="project-modal">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://justinvanwichelen.be/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://justinvanwichelen.be/</loc>
+    <lastmod>2024-07-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/style.css
+++ b/style.css
@@ -442,7 +442,7 @@ iframe {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 12px 28px rgba(0, 0, 0, 0.12);
 }
 
-.hero-text h2 {
+.hero-text h1 {
   font-size: clamp(2.4rem, 5.4vw, 4rem);
   font-weight: bold;
   color: var(--hero-title-text-color);
@@ -453,7 +453,7 @@ iframe {
 }
 
 @media (min-width: 900px) {
-  .hero-text h2 {
+  .hero-text h1 {
     white-space: nowrap;
   }
 }
@@ -607,7 +607,7 @@ iframe {
 }
 
 @media (max-width: 480px) {
-  .hero-text h2 {
+  .hero-text h1 {
     font-size: clamp(2rem, 8vw, 2.4rem);
   }
   .hero-text p {
@@ -958,7 +958,7 @@ iframe {
     max-width: min(520px, 100%);
     text-align: center;
   }
-  .hero-text h2 {
+  .hero-text h1 {
     text-align: center;
   }
   .hero-portrait {


### PR DESCRIPTION
## Summary
- expand SEO metadata with search-engine friendly Open Graph, profile, and structured data updates
- promote Justin Vanwichelen as the primary heading and wrap page sections in a semantic main element
- add sitemap and robots directives so crawlers can index the site effectively

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7d3c71908333b0b95f0480bfa4a4